### PR TITLE
Swift4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ before_install:
   - travis_wait pod repo update --silent
 
 script:
-  - xcodebuild -workspace AeroGearHttp.xcworkspace -scheme AeroGearHttp -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.0' build
-  - xcodebuild -workspace AeroGearHttp.xcworkspace -scheme AeroGearHttpTests -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.0' build test
+  - xcodebuild -workspace AeroGearHttp.xcworkspace -scheme AeroGearHttp -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' build
+  - xcodebuild -workspace AeroGearHttp.xcworkspace -scheme AeroGearHttpTests -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' build test

--- a/AeroGearHttp.xcodeproj/project.pbxproj
+++ b/AeroGearHttp.xcodeproj/project.pbxproj
@@ -549,7 +549,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -571,7 +571,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/AeroGearHttp.xcodeproj/project.pbxproj
+++ b/AeroGearHttp.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		6005304C55CECB8C37FA6B9F /* [CP] Copy Pods Resources */ = {

--- a/AeroGearHttp/Utils.swift
+++ b/AeroGearHttp/Utils.swift
@@ -23,9 +23,8 @@ Handy extensions and utilities.
 extension String {
     
     public func urlEncode() -> String {
-        let allowedCharacters = CharacterSet(charactersIn: "!@#$%&*'();:=+,/?[]")
-        let str = self as NSString
-        return str.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
+        let str = self
+        return str.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
     }
 }
 

--- a/AeroGearHttpTests/RequestSerializerTest.swift
+++ b/AeroGearHttpTests/RequestSerializerTest.swift
@@ -31,20 +31,6 @@ class RequestSerializerTests: XCTestCase {
         super.tearDown()
     }
     
-    @available(iOS 8, *)
-    func testGETWithParameters8() {
-        let url = "http://api.icndb.com/jokes/12"
-        let serialiser = JsonRequestSerializer()
-        let result = serialiser.request(url: URL(string: url)!, method:.get, parameters: ["param1": "value1", "array": ["one", "two", "three", "four"], "numeric": 5])
-        if let urlString = result.url?.absoluteString {
-            XCTAssertTrue(urlString.contains("param1=value1"))
-            XCTAssertTrue(urlString.contains("numeric=5"))
-            XCTAssertTrue(urlString.contains("array%5B%5D=one&array%5B%5D=two&array%5B%5D=three&array%5B%5D=four"))
-        } else {
-            XCTFail("url should not give an empty string")
-        }
-    }
-    
     func testGETWithParameters() {
         let url = "http://api.icndb.com/jokes/12"
         let serialiser = JsonRequestSerializer()

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > This module currently build with Xcode 8 and supports iOS8, iOS9, iOS10.
 
-Thin layer to take care of your http requests working with NSURLSession. 
-Taking care of: 
+Thin layer to take care of your http requests working with NSURLSession.
+Taking care of:
 
 * Json serializer
-* Multipart upload 
+* Multipart upload
 * HTTP Basic/Digest authentication support
 * Pluggable object serialization
 * background processing support
@@ -47,7 +47,7 @@ The library also leverages the build-in foundation support for http/digest authe
 > **NOTE:**  It is advised that HTTPS should be used when performing authentication of this type
 
 ```swift
-let credential = URLCredential(user: "john", 
+let credential = URLCredential(user: "john",
                                  password: "pass",
                                  persistence: .none)
 
@@ -66,7 +66,7 @@ let protectionSpace = URLProtectionSpace(host: "httpbin.org",
                         protocol: NSURLProtectionSpaceHTTP,
                         realm: "me@kennethreitz.com",
                         authenticationMethod: NSURLAuthenticationMethodHTTPDigest)
-        
+
 // setup credential
 // notice that we use '.ForSession' type otherwise credential storage will discard and
 // won't save it when doing 'credentialStorage.setDefaultCredential' later on
@@ -76,11 +76,11 @@ let credential = URLCredential(user: "user",
 // assign it to credential storage
 let credentialStorage = URLCredentialStorage.shared
 credentialStorage.setDefaultCredential(credential, for: protectionSpace);
-        
+
 // set up default configuration and assign credential storage
 let configuration = URLSessionConfiguration.default
 configuration.urlCredentialStorage = credentialStorage
-        
+
 // assign custom configuration to Http
 let http = Http(baseURL: "http://httpbin.org", sessionConfig: configuration)
 http.request(method: .get, path: "/protected/endpoint", completionHandler: {(response, error) in
@@ -90,7 +90,7 @@ http.request(method: .get, path: "/protected/endpoint", completionHandler: {(res
 
 ### OAuth2 Protocol Support
 
-To support the OAuth2 protocol, we have created a separate library [aerogear-ios-oauth2](https://github.com/aerogear/aerogear-ios-oauth2) that can be easily integrated, in order to provide  out-of-the-box support for communicated with OAuth2 protected endpoints. Please have a look at the "Http and OAuth2Module" section on our [documentation page](http://aerogear.org/docs/guides/aerogear-ios-2.X/Authorization/) for more information. 
+To support the OAuth2 protocol, we have created a separate library [aerogear-ios-oauth2](https://github.com/aerogear/aerogear-ios-oauth2) that can be easily integrated, in order to provide  out-of-the-box support for communicated with OAuth2 protected endpoints. Please have a look at the "Http and OAuth2Module" section on our [documentation page](http://aerogear.org/docs/guides/aerogear-ios-2.X/Authorization/) for more information.
 
 Do you want to try it on your end? Follow next section steps.
 
@@ -106,11 +106,11 @@ pod install
 ```
 3. open AeroGearHttp.xcworkspace
 
-## Adding the library to your project 
+## Adding the library to your project
 To add the library in your project, you can either use [CocoaPods](http://cocoapods.org) or manual install in your project. See the respective sections below for instructions:
 
 ### Using [CocoaPods](http://cocoapods.org)
-We recommend you use[CocoaPods-1.1.1 release](https://github.com/CocoaPods/CocoaPods/releases/tag/1.1.1) or greater.
+We recommend you use[CocoaPods-1.2.1 release](https://github.com/CocoaPods/CocoaPods/releases/tag/1.2.1) or greater.
 
 In your ```Podfile``` add:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aerogear-ios-http  [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-http.png)](https://travis-ci.org/aerogear/aerogear-ios-http)
 
-> This module currently build with Xcode 8 and supports iOS8, iOS9, iOS10.
+> This module currently build with Xcode 9 and supports iOS9, iOS10, iOS11.
 
 Thin layer to take care of your http requests working with NSURLSession.
 Taking care of:
@@ -11,7 +11,7 @@ Taking care of:
 * Pluggable object serialization
 * background processing support
 
-100% Swift 3.0.
+100% Swift 4.0.
 
 |                 | Project Info  |
 | --------------- | ------------- |


### PR DESCRIPTION
I've added some changes

1. Use CocoaPods 1.2.1 (as it's the version used by travis)
1. Use default objc inference (it was set to On but we weren't using it and setting it to default removes a warning)
1. Updated the README.md with the Xcode/iOS supported versions and the Swift version
1. Updated the travis scripts to use iOS 11 simulators to run the tests.

There is still a warning we should fix (`aerogear-ios-http/AeroGearHttp/Http.swift:589:23: 'substring(from:)' is deprecated: Please use String slicing subscript with a 'partial range from' operator.`)

And two tests are broken, `testGETWithParameters8` and `testGETWithParameters`
`testGETWithParameters8` can be removed as we dropped iOS 8 support, but `testGETWithParameters` failing probably means that something was broken on the parameter serialization with the migration, so we should look into it before merging 

